### PR TITLE
reorganize content

### DIFF
--- a/Docs/scenario-distributed-tuning-of-hyperparameters.md
+++ b/Docs/scenario-distributed-tuning-of-hyperparameters.md
@@ -194,12 +194,14 @@ We recommend creating a HDInsight Spark cluster to train, evaluate, and apply th
 
 <a name="useamlworkbench"></a>
 ## Model Tuning with Azure Machine Learning (AML) Workbench
+This section mainly outline the step-by-step instructions on how to perform the modeling tuning exercise using AML Workbench. In order to further understand how the machine learning tasks are implemented and why the experiments are performed in such as way, please refer to section [Extended Reading](#details) for details.
+
 We recommend to clone, or download/extract, a copy of [this git repository](https://github.com/Azure/MachineLearningSamples-DistributedHyperParameterTuning) in order to conveniently refer to the files in the [Code](https://github.com/Azure/MachineLearningSamples-DistributedHyperParameterTuning/Code) folder.
 
 We define the 
-"Code" folder of your copy of [this git repository](https://github.com/Azure/MachineLearningSamples-DistributedHyperParameterTuning) as "**origin code**" folder; and the name of your new AML Workbench project folder as "**your project**" folder.
+"Code" folder in your copy of [this git repository](https://github.com/Azure/MachineLearningSamples-DistributedHyperParameterTuning) as "**origin code**" folder; and the name of your new created AML Workbench project folder as "**your project**" folder. Blew section shows how this new project is created.
 
-This section mainly outline the step-by-step instructions on how to perform the modeling tuning exercise using AML Workbench. In order to further understand how the machine learning tasks are implemented and why the experiments are performed in such as way, please refer to section [Extended Reading](#details) for details.
+
 
 <a name="createproj"></a>
 ### Create a New Project
@@ -308,7 +310,7 @@ In the top right corner of Run Properties window there is a section Output Files
       	  version: "0.2.0"
 
 <a name="details"></a>
-##Extended Reading
+## Extended Reading
 This section is for further understanding the machine learning process. It is not required in order to finish the model turning exercise.
 
 <a name="featurnengineering"></a>


### PR DESCRIPTION
Several major proposed modifications:
1. I consider to separate the step-by-step instructions from explaining why we do such and such, so that the user gets a clear flow.
2. Two types of compute environments : remote Docker and Spark cluster, should be described in two paths, not mingled together.
3. I prefer to make it clear into steps, instead of assuming the user know it. e.g. Replacing the account name and key for storage account in load_data.py. I made it a clear step instead of making the user to infer. 
4. I use "mydsvm, myspark" to replace "dsvm, spark" to remind user these are not reserved words
5. I prefer not to use screenshots, as it need a lot future maintenance when visual feature changes. But I still keeps some screenshots. This is just my personal opinion.