### PR TITLE
reorganize content

### DIFF
--- a/Docs/scenario-distributed-tuning-of-hyperparameters.md
+++ b/Docs/scenario-distributed-tuning-of-hyperparameters.md
@@ -426,7 +426,7 @@ The final code for tuning hyperparameters using Spark is in distributed\_sweep.p
 ## Architecture diagram
 
 The following diagram shows end-to-end workflow:
-![architecture](../Images/architecture.PNG) 
+![architecture](../Images/architecture.png) 
 
 
 <a name="conclusion"></a>


### PR DESCRIPTION
Several major proposed modifications:
1.	I consider to separate the step-by-step instructions from explaining why we do such and such, so that the user gets a clear flow.
2.	Two types of compute environments : remote Docker and Spark cluster, should be described in two paths, not mingled together.
3.	I prefer to make it clear into steps, instead of assuming the user know it. e.g. Replacing the account name and key for storage account in load_data.py. I made it a clear step instead of making the user to infer.
4.	I use "mydsvm, myspark" to replace "dsvm, spark" to remind user these are not reserved words
5.	I prefer not to use screenshots, as it need a lot future maintenance when visual feature changes. But I still keeps some screenshots. This is just my personal opinion.
